### PR TITLE
Migrate from Laravel Mix to Vite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /node_modules
 /public/hot
+/public/build
 /public/storage
 /storage/*.key
 /vendor

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
         "@tailwindcss/typography": "^0.5.10",
         "autoprefixer": "^10.4.17",
         "postcss": "^8.4.33",
-        "tailwindcss": "^3.4.1"
+        "tailwindcss": "^3.4.1",
+        "vite": "^3.0.2",
+        "laravel-vite-plugin": "^0.6.0"
     },
     "type": "module"
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+    plugins: {
+        tailwindcss: {},
+        autoprefixer: {},
+    },
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,11 +1,11 @@
 import { defineConfig } from 'vite';
 import laravel from 'laravel-vite-plugin';
- 
+
 export default defineConfig({
     plugins: [
-        laravel([
-            'resources/css/app.css',
-            'resources/js/app.js',
-        ]),
+        laravel({
+            input: ['resources/css/app.css', 'resources/js/app.js'],
+            refresh: true,
+        }),
     ],
 });


### PR DESCRIPTION
This pull request includes changes for migrating from Laravel Mix to Vite outlined in [Migration Guide](https://github.com/laravel/vite-plugin/blob/main/UPGRADE.md#migrating-from-laravel-mix-to-vite) and automated by the [Vite Converter](https://laravelshift.com/convert-laravel-mix-to-vite).

**Before merging**, you need to:

- Checkout the `shift-108988` branch
- Run `composer update`
- Run `npm install`
- Review **all** comments for additional changes 
- Thoroughly test your application ([no tests?](https://laravelshift.com/laravel-test-generator), [no CI?](https://laravelshift.com/ci-generator))

Please send your feedback to shift@laravelshift.com or share the good vibes on [Twitter](https://twitter.com/laravelshift).
